### PR TITLE
Add support for bounces in transactional email

### DIFF
--- a/Mail/sparkpost.php
+++ b/Mail/sparkpost.php
@@ -112,7 +112,8 @@ class Mail_sparkpost extends Mail {
       if (CRM_Utils_Array::value('Return-Path', $headers)) {
         $metadata = explode(CRM_Core_Config::singleton()->verpSeparator, CRM_Utils_Array::value("Return-Path", $headers));
         if ($metadata[0] == 'm') {
-          $sp['metadata'] = array('X-CiviMail-Bounce' => CRM_Utils_Array::value("Return-Path", $headers));
+          $localpart = CRM_Sparkpost::getDomainLocalpart();
+          $sp['metadata'] = array('X-CiviMail-Bounce' => $localpart . CRM_Utils_Array::value("Return-Path", $headers));
         }
       }
     }


### PR DESCRIPTION
Add support for bounces in transactional email.

There is 2 parts in the PR:
- ensure that the email used for transactional email is added to the job queue instead of assuming it's the master email. It will avoid disabling the wrong email in case of bounces
- adding localpart (e.g. `civimail+`) to the X-CiviMail-Bounce otherwise CRM_Sparkpost::getPartsFromBounceID isn't able to extract the information